### PR TITLE
fix(assert): fix handling of undefined or null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+sudo: false
+language: node_js
+node_js: stable

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "npm rm comment-to-assert && npm i && node example.js"
+    "test": "npm i && node example.js"
   },
   "author": "azu",
   "license": "MIT",

--- a/src/ast-utils.js
+++ b/src/ast-utils.js
@@ -3,7 +3,9 @@
 import { Syntax } from "estraverse";
 import assert from "assert";
 import toAST from "tagged-template-to-ast";
+
 const commentCodeRegExp = /=>\s*?(.*?)$/i;
+
 export function tryGetCodeFromComments(comments) {
     if (comments.length === 0) {
         return;
@@ -16,6 +18,7 @@ export function tryGetCodeFromComments(comments) {
         return matchResult[1];
     }
 }
+
 function isConsole(node) {
     const expression = node.expression;
     if (!expression) {
@@ -35,19 +38,24 @@ function isConsole(node) {
         return true;
     }
 }
+
 function extractionBody(ast) {
     return ast.body[0];
 }
+
 export const ERROR_COMMENT_PATTERN = /^([a-zA-Z]*?Error)/;
+
 export function wrapAssert(actualNode, expectedNode) {
     assert(typeof expectedNode !== "undefined");
-    var type = expectedNode.type || extractionBody(expectedNode).type;
+    const type = expectedNode.type || extractionBody(expectedNode).type;
     if (type === Syntax.Identifier && ERROR_COMMENT_PATTERN.test(expectedNode.name)) {
         return toAST`assert.throws(function() {
                     ${actualNode}
                })`;
     } else if (type === Syntax.Identifier && expectedNode.name === "NaN") {
         return toAST`assert(isNaN(${actualNode}));`;
+    } else if (expectedNode.name === "undefined" || expectedNode.name === "null") {
+        return toAST`assert.equal(${actualNode}, ${expectedNode})`;
     } else if (isConsole(actualNode)) {
         const args = actualNode.expression.arguments;
         const firstArg = args[0];

--- a/test/comment-to-assert-test.js
+++ b/test/comment-to-assert-test.js
@@ -12,6 +12,7 @@ function parseToAST(code) {
     };
     return parse(code, parseOption);
 }
+
 describe("comment-to-assert", function() {
     describe("#toAssertFromSource", function() {
         it("test", function() {
@@ -92,6 +93,18 @@ describe("comment-to-assert", function() {
             var result = toAssertFromAST(AST);
             var expected = `var a = "str";
             assert.equal(a, "str");`;
+            astEqual(result, expected);
+        });
+        it("could handle undefined", function() {
+            var AST = parseToAST(`this; // => undefined`);
+            var result = toAssertFromAST(AST);
+            var expected = `assert.equal(this, undefined);`;
+            astEqual(result, expected);
+        });
+        it("could handle null", function() {
+            var AST = parseToAST(`this; // => null`);
+            var result = toAssertFromAST(AST);
+            var expected = `assert.equal(this, null);`;
             astEqual(result, expected);
         });
         it("can transform multiple comments", function() {


### PR DESCRIPTION
```
this ;// => undefined
```

to be

```
assert.equal(this, undefined)
```