### PR TITLE
feat(assert): use `strictEqual` and `deepStrictEqual`

### DIFF
--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -55,7 +55,7 @@ export function wrapAssert(actualNode: any, expectedNode: any): any {
             ARGS
         });
     } else if (isIdentifier(expectedNode) && expectedNode.name === "NaN") {
-        return template`assert(isNaN(ACTUAL_NODE));`({
+        return template`assert.ok(isNaN(ACTUAL_NODE));`({
             ACTUAL_NODE
         });
     } else if (isNullLiteral(expectedNode)) {

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -59,20 +59,20 @@ export function wrapAssert(actualNode: any, expectedNode: any): any {
             ACTUAL_NODE
         });
     } else if (isNullLiteral(expectedNode)) {
-        return template`assert.equal(ACTUAL_NODE, null)`({
+        return template`assert.strictEqual(ACTUAL_NODE, null)`({
             ACTUAL_NODE
         });
     } else if (isIdentifier(expectedNode) && expectedNode.name === "undefined") {
-        return template`assert.equal(ACTUAL_NODE, undefined)`({
+        return template`assert.strictEqual(ACTUAL_NODE, undefined)`({
             ACTUAL_NODE
         });
     } else if (isLiteral(expectedNode)) {
-        return template`assert.equal(ACTUAL_NODE, EXPECTED_NODE)`({
+        return template`assert.strictEqual(ACTUAL_NODE, EXPECTED_NODE)`({
             ACTUAL_NODE,
             EXPECTED_NODE
         });
     } else {
-        return template`assert.deepEqual(ACTUAL_NODE, EXPECTED_NODE)`({
+        return template`assert.deepStrictEqual(ACTUAL_NODE, EXPECTED_NODE)`({
             ACTUAL_NODE,
             EXPECTED_NODE
         });

--- a/test/snapshot-test.ts
+++ b/test/snapshot-test.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as assert from "assert";
+import * as vm from "vm";
 import { toAssertFromSource } from "../src/comment-to-assert";
 
 const fixturesDir = path.join(__dirname, "snapshots");
@@ -28,6 +29,14 @@ ${fixtureDir}
 ${JSON.stringify(actual)}
 `
             );
+            if (typeof actual === "string") {
+                vm.runInContext(
+                    actual,
+                    vm.createContext({
+                        assert
+                    })
+                );
+            }
         });
     });
 });

--- a/test/snapshots/Array/output.js
+++ b/test/snapshots/Array/output.js
@@ -1,2 +1,2 @@
 var a = [1];
-assert.deepEqual(a, [1]); // => [1]
+assert.deepStrictEqual(a, [1]); // => [1]

--- a/test/snapshots/BinaryExpression/input.js
+++ b/test/snapshots/BinaryExpression/input.js
@@ -1,4 +1,4 @@
 var a = function() {
     return 1;
 };
-a + 1; // => 2
+a() + 1; // => 2

--- a/test/snapshots/BinaryExpression/output.js
+++ b/test/snapshots/BinaryExpression/output.js
@@ -2,4 +2,4 @@ var a = function () {
   return 1;
 };
 
-assert.strictEqual(a + 1, 2); // => 2
+assert.strictEqual(a() + 1, 2); // => 2

--- a/test/snapshots/BinaryExpression/output.js
+++ b/test/snapshots/BinaryExpression/output.js
@@ -2,4 +2,4 @@ var a = function () {
   return 1;
 };
 
-assert.equal(a + 1, 2); // => 2
+assert.strictEqual(a + 1, 2); // => 2

--- a/test/snapshots/BlockComent/output.js
+++ b/test/snapshots/BlockComent/output.js
@@ -1,2 +1,2 @@
-assert.equal(1, 1);
+assert.strictEqual(1, 1);
 /* => 1 */

--- a/test/snapshots/CallExpression/output.js
+++ b/test/snapshots/CallExpression/output.js
@@ -2,4 +2,4 @@ var a = function () {
   return 1;
 };
 
-assert.equal(a(), 1); // => 1
+assert.strictEqual(a(), 1); // => 1

--- a/test/snapshots/ConsoleLog/output.js
+++ b/test/snapshots/ConsoleLog/output.js
@@ -1,6 +1,6 @@
-assert.equal(null, null); // => null
+assert.strictEqual(null, null); // => null
 
-assert.equal(1, 1); // => 1
+assert.strictEqual(1, 1); // => 1
 
 const a = "str";
-assert.equal(a, "str"); // => "str"
+assert.strictEqual(a, "str"); // => "str"

--- a/test/snapshots/NaN/output.js
+++ b/test/snapshots/NaN/output.js
@@ -1,1 +1,1 @@
-assert(isNaN(NaN)); // => NaN
+assert.ok(isNaN(NaN)); // => NaN

--- a/test/snapshots/Promise.resolve/output.js
+++ b/test/snapshots/Promise.resolve/output.js
@@ -1,4 +1,4 @@
 Promise.resolve(Promise.resolve(1)).then(v => {
-  assert.equal(v, 1);
+  assert.strictEqual(v, 1);
   return v;
 }); // => Promise: 1

--- a/test/snapshots/cnsole.log.Promise.resolve/output.js
+++ b/test/snapshots/cnsole.log.Promise.resolve/output.js
@@ -1,4 +1,4 @@
 Promise.resolve(Promise.resolve(1)).then(v => {
-  assert.equal(v, 1);
+  assert.strictEqual(v, 1);
   return v;
 }); // => Promise: 1

--- a/test/snapshots/multiple-comments/output.js
+++ b/test/snapshots/multiple-comments/output.js
@@ -1,3 +1,3 @@
-assert.equal(1, 1); // => 1
+assert.strictEqual(1, 1); // => 1
 
-assert.equal(2, 2); // => 2
+assert.strictEqual(2, 2); // => 2

--- a/test/snapshots/null-literal/output.js
+++ b/test/snapshots/null-literal/output.js
@@ -1,1 +1,1 @@
-assert.equal(null, null); // => null
+assert.strictEqual(null, null); // => null

--- a/test/snapshots/number-literal/output.js
+++ b/test/snapshots/number-literal/output.js
@@ -1,1 +1,1 @@
-assert.equal(1, 1); // => 1
+assert.strictEqual(1, 1); // => 1

--- a/test/snapshots/string-literal/output.js
+++ b/test/snapshots/string-literal/output.js
@@ -1,2 +1,2 @@
 // avoid to directive literal
-assert.equal("str", "str"); // =>"str"
+assert.strictEqual("str", "str"); // =>"str"

--- a/test/snapshots/undefined/input.js
+++ b/test/snapshots/undefined/input.js
@@ -1,1 +1,1 @@
-this; // => undefined
+undefined; // => undefined

--- a/test/snapshots/undefined/output.js
+++ b/test/snapshots/undefined/output.js
@@ -1,1 +1,1 @@
-assert.strictEqual(this, undefined); // => undefined
+assert.strictEqual(undefined, undefined); // => undefined

--- a/test/snapshots/undefined/output.js
+++ b/test/snapshots/undefined/output.js
@@ -1,1 +1,1 @@
-assert.equal(this, undefined); // => undefined
+assert.strictEqual(this, undefined); // => undefined

--- a/test/snapshots/variable-expeceted-object/output.js
+++ b/test/snapshots/variable-expeceted-object/output.js
@@ -1,6 +1,6 @@
 var a = {
   a: 1
 };
-assert.deepEqual(a, {
+assert.deepStrictEqual(a, {
   a: 1
 }); // => { a : 1 }

--- a/test/snapshots/variable/output.js
+++ b/test/snapshots/variable/output.js
@@ -1,2 +1,2 @@
 const a = 1;
-assert.equal(a, 1); // => 1
+assert.strictEqual(a, 1); // => 1


### PR DESCRIPTION
BREAKING CHANGE: assertion is strict by default

fix #6 